### PR TITLE
Added timeout when calling wait on thread

### DIFF
--- a/paramiko/_version.py
+++ b/paramiko/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (2, 4, 0, 'lge-custom-3.0')
+__version_info__ = (2, 4, 1, 'lge-custom-3.0')
 __version__ = '.'.join(map(str, __version_info__))

--- a/paramiko/channel.py
+++ b/paramiko/channel.py
@@ -214,7 +214,7 @@ class Channel (ClosingContextManager):
         self._wait_for_event()
 
     @open_only
-    def exec_command(self, command):
+    def exec_command(self, command, timeout=90):
         """
         Execute a command on the server.  If the server allows it, the channel
         will then be directly connected to the stdin, stdout, and stderr of
@@ -225,6 +225,8 @@ class Channel (ClosingContextManager):
         another command.
 
         :param str command: a shell command to execute.
+
+        :param int timeout: set thread timeout when waiting for event
 
         :raises:
             `.SSHException` -- if the request was rejected or the channel was
@@ -238,7 +240,7 @@ class Channel (ClosingContextManager):
         m.add_string(command)
         self._event_pending()
         self.transport._send_user_message(m)
-        self._wait_for_event()
+        self._wait_for_event(timeout=timeout)
 
     @open_only
     def invoke_subsystem(self, subsystem):
@@ -1187,8 +1189,8 @@ class Channel (ClosingContextManager):
         self.event.clear()
         self.event_ready = False
 
-    def _wait_for_event(self):
-        self.event.wait()
+    def _wait_for_event(self, timeout=None):
+        self.event.wait(timeout=timeout)
         assert self.event.is_set()
         if self.event_ready:
             return


### PR DESCRIPTION
When connected to a ssh server that goes down during call to
'paramiko.client.SshClient.exec_command', it can cause a hang during
the call to 'wait' on the event thread. 'wait' does take a timeout, and
such does 'exec_command', but the timeout in exec_command is never
passed down to 'wait'. This patch does so.

refs:https://github.com/paramiko/paramiko/pull/1086/commits/e8d1014d305d312fceb6cf7c6a6096ffd45a60d0